### PR TITLE
Review fixes for geqdsk reader

### DIFF
--- a/08-mast-upgrade.py
+++ b/08-mast-upgrade.py
@@ -7,7 +7,7 @@ from freegs.plotting import plotConstraints
 # Create the machine, which specifies coil locations
 # and equilibrium, specifying the domain to solve over
 
-tokamak = freegs.machine.MASTU()
+tokamak = freegs.machine.MASTU_simple()
 
 
 eq = freegs.Equilibrium(tokamak=tokamak,

--- a/12-limited.py
+++ b/12-limited.py
@@ -57,7 +57,7 @@ freegs.solve(eq,
              profiles, 
              constrain,
              show=True,
-			 check_limited = True
+			 check_limited = True,
 		     limit_it = 0)
 
 # eq now contains the solution

--- a/freegs/control.py
+++ b/freegs/control.py
@@ -295,22 +295,9 @@ class ConstrainPsiNorm2D(object):
         eq.getMachine().setControlCurrents(currents)
         psi = eq.psi()
 
-        opt, xpt = critical.find_critical(eq.R, eq.Z, psi)
-        if not opt:
-            print("No O-points found!")
-            print(opt, xpt)
-            eq.plot()
-            raise ValueError("No O-points found!")
-        psi_axis = opt[0][2]
-
-        '''
-        if not xpt:
-            print("No X-points found!")
-            eq.plot()
-            raise ValueError("No X-points found")
-        '''
-
+        eq._updateBoundaryPsi(psi)
         psi_bndry = eq.psi_bndry
+        psi_axis = eq.psi_axis
 
         # Calculate normalised psi.
         # 0 = magnetic axis

--- a/freegs/equilibrium.py
+++ b/freegs/equilibrium.py
@@ -487,7 +487,6 @@ class Equilibrium:
         if opt:
         # Magnetic axis flux taken as primary o-point flux
             self.psi_axis = opt[0][2]
-
             '''
             Several options depending on if user wishes to check
             if the plasma becomes limited.
@@ -495,7 +494,6 @@ class Equilibrium:
 
             # The user wishes to check if the plasma is limited
             if(self.check_limited and self.tokamak.wall):
-
                 # A wall has actually been provided, proceed with checking
 
                 # Obtain flux on machine limit points
@@ -513,6 +511,7 @@ class Equilibrium:
                 '''
 
                 if xpt:
+                    #print('Opoint present and checking limited and xpoint present')
                     limit_args = np.ravel(np.argwhere(abs(Zlimit)<abs(0.75*xpt[0][1])))
                     Rlimit = Rlimit[limit_args]
                     Zlimit = Zlimit[limit_args]
@@ -541,7 +540,6 @@ class Equilibrium:
 
                 # Check if any xpoints are present
                 if xpt:
-
                     # Get flux from the primary xpoint
                     self.psi_xpt = xpt[0][2]
 
@@ -563,7 +561,6 @@ class Equilibrium:
                     )
 
                 else:
-
                     # No xpoints, therefore psi_bndry = psi_limit
                     self.psi_bndry = self.psi_limit
                     self.is_limited = True
@@ -572,7 +569,6 @@ class Equilibrium:
             else:
                 # Either a wall was not provided or the user did not wish to
                 # check if the plasma was limited
-
                 if xpt:
                     self.psi_xpt = xpt[0][2]
                     self.psi_bndry = self.psi_xpt

--- a/freegs/filament_coil.py
+++ b/freegs/filament_coil.py
@@ -231,7 +231,6 @@ class FilamentCoil(Coil):
         if Rfil is None:
             # No filaments provided. Need to populate the coil cross
             # section with -Nfils filaments.
-
             Rfil, Zfil = populate_with_fils(self.shape,Nfils)
         
         Rfil = np.asarray(Rfil)

--- a/freegs/picard.py
+++ b/freegs/picard.py
@@ -189,6 +189,9 @@ def solve(
             # The user wants to wait for a limited plasma. The plasma is not limited.
             ok_to_break = False
 
+        print('psi_relchange: '+str(psi_relchange))
+        print('bndry_relchange: '+str(bndry_relchange))
+
         # Check if the changes in psi are small enough and that it is ok to start checking for convergence
         if(((psi_maxchange < atol) or (psi_relchange < rtol)) and bndry_relchange < rtol and ok_to_break):
             break


### PR DESCRIPTION
Fixes in control regarding reading in qedsks > was not working correctly with the new syntax implemented when limited plasmas were added to freegs.

Note: 08-MASTU example script does not produce a solution. Upon further investigation, although this did work in the pre-limited-plasmas version of freegs, and hence this lack of solution should not be due to the recent limited plasma changes.